### PR TITLE
! expose counters with _total suffix conform prometheus best practices

### DIFF
--- a/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
+++ b/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
@@ -33,12 +33,12 @@ class ScrapeDataBuilder(prometheusConfig: PrometheusReporter.Configuration) {
     builder.toString()
 
   def appendCounters(counters: Seq[MetricValue]): ScrapeDataBuilder = {
-    counters.groupBy(_.name).foreach(appendValueMetric("counter"))
+    counters.groupBy(_.name).foreach(appendValueMetric("counter", alwaysIncreasing = true))
     this
   }
 
   def appendGauges(gauges: Seq[MetricValue]): ScrapeDataBuilder = {
-    gauges.groupBy(_.name).foreach(appendValueMetric("gauge"))
+    gauges.groupBy(_.name).foreach(appendValueMetric("gauge", alwaysIncreasing = false))
     this
   }
 
@@ -47,12 +47,12 @@ class ScrapeDataBuilder(prometheusConfig: PrometheusReporter.Configuration) {
     this
   }
 
-
-
-  private def appendValueMetric(metricType: String)(group: (String, Seq[MetricValue])): Unit = {
+  private def appendValueMetric(metricType: String, alwaysIncreasing: Boolean)(group: (String, Seq[MetricValue])): Unit = {
     val (metricName, snapshots) = group
     val unit = snapshots.headOption.map(_.unit).getOrElse(none)
-    val normalizedMetricName = normalizeMetricName(metricName, unit)
+    val normalizedMetricName = normalizeMetricName(metricName, unit) + {
+      if(alwaysIncreasing) "_total" else ""
+    }
 
     append("# TYPE ").append(normalizedMetricName).append(" ").append(metricType).append("\n")
 

--- a/src/test/scala/kamon/prometheus/ScrapeDataBuilderSpec.scala
+++ b/src/test/scala/kamon/prometheus/ScrapeDataBuilderSpec.scala
@@ -17,8 +17,8 @@ class ScrapeDataBuilderSpec extends WordSpec with Matchers {
         .appendGauges(Seq(gaugeOne))
         .build() should include {
           """
-            |# TYPE counter_one_seconds counter
-            |counter_one_seconds 10.0
+            |# TYPE counter_one_seconds_total counter
+            |counter_one_seconds_total 10.0
             |# TYPE gauge_one_seconds gauge
             |gauge_one_seconds 20.0
           """.stripMargin.trim()
@@ -34,8 +34,8 @@ class ScrapeDataBuilderSpec extends WordSpec with Matchers {
       .appendGauges(Seq(gaugeOne))
       .build() should include {
         """
-          |# TYPE counter_one_bytes counter
-          |counter_one_bytes 10.0
+          |# TYPE counter_one_bytes_total counter
+          |counter_one_bytes_total 10.0
           |# TYPE gauge_one_bytes gauge
           |gauge_one_bytes 20.0
         """.stripMargin.trim()
@@ -51,8 +51,8 @@ class ScrapeDataBuilderSpec extends WordSpec with Matchers {
       .appendGauges(Seq(gaugeOne))
       .build() should include {
         """
-          |# TYPE counter_one_seconds counter
-          |counter_one_seconds{tag_with_dots="value"} 10.0
+          |# TYPE counter_one_seconds_total counter
+          |counter_one_seconds_total{tag_with_dots="value"} 10.0
           |# TYPE gauge_one_seconds gauge
           |gauge_one_seconds 20.0
         """.stripMargin.trim()
@@ -66,11 +66,11 @@ class ScrapeDataBuilderSpec extends WordSpec with Matchers {
 
       builder().appendCounters(Seq(counterOne, counterTwo, counterOneWithTag)).build() should include {
         """
-          |# TYPE counter_one counter
-          |counter_one 10.0
-          |counter_one{t="v"} 30.0
-          |# TYPE counter_two counter
-          |counter_two 20.0
+          |# TYPE counter_one_total counter
+          |counter_one_total 10.0
+          |counter_one_total{t="v"} 30.0
+          |# TYPE counter_two_total counter
+          |counter_two_total 20.0
         """.stripMargin.trim()
       }
 


### PR DESCRIPTION
First of all thanks for creating this bridge. Prometheus recommends suffixing counters with "_total" to indicate their accumulating nature, see https://prometheus.io/docs/practices/naming/#metric-names . This PR changes exposure of counters accordingly. 
