### PR TITLE
= fixed type error in conditional check for magnitude normalization

### DIFF
--- a/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
+++ b/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
@@ -173,8 +173,8 @@ class ScrapeDataBuilder(prometheusConfig: PrometheusReporter.Configuration) {
     numberFormat.format(value)
 
   private def scale(value: Long, unit: MeasurementUnit): Double = unit.dimension match {
-    case Time         if unit.magnitude != time.seconds       => MeasurementUnit.scale(value, unit, time.seconds)
-    case Information  if unit.magnitude != information.bytes  => MeasurementUnit.scale(value, unit, information.bytes)
+    case Time         if unit.magnitude != time.seconds.magnitude       => MeasurementUnit.scale(value, unit, time.seconds)
+    case Information  if unit.magnitude != information.bytes.magnitude  => MeasurementUnit.scale(value, unit, information.bytes)
     case _ => value
   }
 


### PR DESCRIPTION
The conditional check for normalizing the magnitude of a value checks two unrelated types.