### PR TITLE
Backport to Kamon 0.6.7

### DIFF
--- a/src/main/scala/kamon/ReporterRegistry.scala
+++ b/src/main/scala/kamon/ReporterRegistry.scala
@@ -1,0 +1,14 @@
+package kamon
+
+import com.typesafe.config.Config
+import kamon.metric.TickSnapshot
+
+sealed trait Reporter {
+  def start(): Unit
+  def stop(): Unit
+  def reconfigure(config: Config): Unit
+}
+
+trait MetricReporter extends Reporter {
+  def reportTickSnapshot(snapshot: TickSnapshot): Unit
+}

--- a/src/main/scala/kamon/metric/DynamicRange.scala
+++ b/src/main/scala/kamon/metric/DynamicRange.scala
@@ -1,0 +1,48 @@
+/* =========================================================================================
+ * Copyright © 2013-2017 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.metric
+
+import java.util.concurrent.TimeUnit
+
+case class DynamicRange(lowestDiscernibleValue: Long, highestTrackableValue: Long, significantValueDigits: Int) {
+  def upTo(highestTrackableValue: Long): DynamicRange =
+    copy(highestTrackableValue = highestTrackableValue)
+
+  def withLowestDiscernibleValue(lowestDiscernibleValue: Long): DynamicRange =
+    copy(lowestDiscernibleValue = lowestDiscernibleValue)
+}
+
+object DynamicRange {
+  private val oneHourInNanoseconds = TimeUnit.HOURS.toNanos(1)
+
+  /**
+    * Provides a range from 0 to 3.6e+12 (one hour in nanoseconds) with a value precision of 1 significant digit (10%)
+    * across that range.
+    */
+  val Loose = DynamicRange(1L, oneHourInNanoseconds, 1)
+
+  /**
+    * Provides a range from 0 to 3.6e+12 (one hour in nanoseconds) with a value precision of 2 significant digit (1%)
+    * across that range.
+    */
+  val Default = DynamicRange(1L, oneHourInNanoseconds, 2)
+
+  /**
+    * Provides a range from 0 to 3.6e+12 (one hour in nanoseconds) with a value precision of 3 significant digit (0.1%)
+    * across that range.
+    */
+  val Fine = DynamicRange(1L, oneHourInNanoseconds, 3)
+}

--- a/src/main/scala/kamon/metric/Histogram.scala
+++ b/src/main/scala/kamon/metric/Histogram.scala
@@ -1,0 +1,236 @@
+/* =========================================================================================
+ * Copyright © 2013-2017 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.metric
+
+import java.nio.ByteBuffer
+
+import org.HdrHistogram._
+
+trait Histogram {
+  def unit: MeasurementUnit
+  def dynamicRange: DynamicRange
+
+  def record(value: Long): Unit
+  def record(value: Long, times: Long): Unit
+}
+
+private[kamon] class HdrHistogram(
+  name: String,
+  tags: Map[String, String],
+  val unit: MeasurementUnit,
+  val dynamicRange: DynamicRange
+) extends SimpleHistogramExtension(dynamicRange)
+    with Histogram
+    with SnapshotCreation {
+
+  def record(value: Long): Unit =
+    tryRecord(value, 1)
+
+  def record(value: Long, count: Long): Unit =
+    tryRecord(value, count)
+
+  private[kamon] def snapshot(resetState: Boolean): MetricDistribution =
+    snapshot(resetState, unit, name, tags)
+
+  private def tryRecord(value: Long, count: Long): Unit =
+    recordValueWithCount(value, count)
+}
+
+private[kamon] trait SnapshotCreation { self: HdrHistogramOps with Histogram =>
+
+  private[kamon] def snapshot(
+    resetState: Boolean,
+    unit: MeasurementUnit,
+    name: String,
+    tags: Map[String, String]
+  ): MetricDistribution = {
+    SnapshotCreation.snapshot(this, resetState, unit, dynamicRange, name, tags)
+  }
+}
+
+private[kamon] object SnapshotCreation {
+  // TODO: maybe make the buffer size configurable or make it auto-expanding.
+  private val tempSnapshotBuffer = new ThreadLocal[ByteBuffer] {
+    override def initialValue(): ByteBuffer = ByteBuffer.allocate(33792)
+  }
+
+  def snapshot[T <: HdrHistogramOps](
+    hdrOps: T,
+    resetState: Boolean,
+    unit: MeasurementUnit,
+    dynamicRange: DynamicRange,
+    name: String,
+    tags: Map[String, String]
+  ): MetricDistribution = {
+    val buffer = SnapshotCreation.tempSnapshotBuffer.get()
+    val countsLimit = hdrOps.getCountsArraySize()
+    var index = 0
+    buffer.clear()
+
+    var minIndex = Int.MaxValue
+    var maxIndex = 0
+    var totalCount = 0L
+
+    while (index < countsLimit) {
+      val countAtIndex =
+        if (resetState) hdrOps.getAndSetFromCountsArray(index, 0L) else hdrOps.getFromCountsArray(index)
+
+      var zerosCount = 0L
+      if (countAtIndex == 0L) {
+        index += 1
+        zerosCount = 1
+        while (index < countsLimit && hdrOps.getFromCountsArray(index) == 0L) {
+          index += 1
+          zerosCount += 1
+        }
+      }
+
+      if (zerosCount > 0) {
+        if (index < countsLimit)
+          ZigZag.putLong(buffer, -zerosCount)
+      } else {
+        if (minIndex > index)
+          minIndex = index
+        maxIndex = index
+
+        index += 1
+        totalCount += countAtIndex
+        ZigZag.putLong(buffer, countAtIndex)
+      }
+    }
+
+    buffer.flip()
+    val zigZagCounts = Array.ofDim[Byte](buffer.limit())
+    buffer.get(zigZagCounts)
+
+    val distribution = new ZigZagCountsDistribution(
+      totalCount,
+      minIndex,
+      maxIndex,
+      ByteBuffer.wrap(zigZagCounts),
+      hdrOps.protectedUnitMagnitude(),
+      hdrOps.protectedSubBucketHalfCount(),
+      hdrOps.protectedSubBucketHalfCountMagnitude()
+    )
+
+    MetricDistribution(name, tags, unit, dynamicRange, distribution)
+  }
+
+  class ZigZagCountsDistribution(
+    val count: Long,
+    minIndex: Int,
+    maxIndex: Int,
+    val zigZagCounts: ByteBuffer,
+    unitMagnitude: Int,
+    subBucketHalfCount: Int,
+    subBucketHalfCountMagnitude: Int
+  ) extends Distribution {
+
+    val min: Long = if (count == 0) 0 else bucketValueAtIndex(minIndex)
+    val max: Long = bucketValueAtIndex(maxIndex)
+    def sum: Long = bucketsIterator.foldLeft(0L)((a, b) => a + (b.value * b.frequency))
+
+    def buckets: Seq[Bucket] = {
+      val builder = Vector.newBuilder[Bucket]
+      bucketsIterator.foreach { b =>
+        builder += DefaultBucket(b.value, b.frequency)
+      }
+
+      builder.result()
+    }
+
+    def bucketsIterator: Iterator[Bucket] = new Iterator[Bucket] {
+      val buffer = zigZagCounts.duplicate()
+      val bucket = MutableBucket(0, 0)
+      var countsArrayIndex = 0
+
+      def hasNext: Boolean =
+        buffer.remaining() > 0
+
+      def next(): Bucket = {
+        val readLong = ZigZag.getLong(buffer)
+        val frequency = if (readLong > 0) {
+          readLong
+        } else {
+          countsArrayIndex += (-readLong.toInt)
+          ZigZag.getLong(buffer)
+        }
+
+        bucket.value = bucketValueAtIndex(countsArrayIndex)
+        bucket.frequency = frequency
+        countsArrayIndex += 1
+        bucket
+      }
+    }
+
+    def percentilesIterator: Iterator[Percentile] = new Iterator[Percentile] {
+      val buckets = bucketsIterator
+      val percentile = MutablePercentile(0D, 0, 0)
+      var countUnderQuantile = 0L
+
+      def hasNext: Boolean =
+        buckets.hasNext
+
+      def next(): Percentile = {
+        val bucket = buckets.next()
+        countUnderQuantile += bucket.frequency
+        percentile.quantile = (countUnderQuantile * 100D) / ZigZagCountsDistribution.this.count
+        percentile.countUnderQuantile = countUnderQuantile
+        percentile.value = bucket.value
+        percentile
+      }
+    }
+
+    def percentile(p: Double): Percentile = {
+      val percentiles = percentilesIterator
+      if (percentiles.hasNext) {
+        var currentPercentile = percentiles.next()
+        while (percentiles.hasNext && currentPercentile.quantile < p) {
+          currentPercentile = percentiles.next()
+        }
+
+        currentPercentile
+
+      } else DefaultPercentile(p, 0, 0)
+    }
+
+    def percentiles: Seq[Percentile] = {
+      val builder = Vector.newBuilder[Percentile]
+      percentilesIterator.foreach { p =>
+        builder += DefaultPercentile(p.quantile, p.value, p.countUnderQuantile)
+      }
+
+      builder.result()
+    }
+
+    @inline private def bucketValueAtIndex(index: Int): Long = {
+      var bucketIndex: Int = (index >> subBucketHalfCountMagnitude) - 1
+      var subBucketIndex: Int = (index & (subBucketHalfCount - 1)) + subBucketHalfCount
+      if (bucketIndex < 0) {
+        subBucketIndex -= subBucketHalfCount
+        bucketIndex = 0
+      }
+
+      subBucketIndex.toLong << (bucketIndex + unitMagnitude)
+    }
+  }
+
+  case class DefaultBucket(value: Long, frequency: Long) extends Bucket
+  case class MutableBucket(var value: Long, var frequency: Long) extends Bucket
+
+  case class DefaultPercentile(quantile: Double, value: Long, countUnderQuantile: Long) extends Percentile
+  case class MutablePercentile(var quantile: Double, var value: Long, var countUnderQuantile: Long) extends Percentile
+}

--- a/src/main/scala/kamon/metric/MeasurementUnit.scala
+++ b/src/main/scala/kamon/metric/MeasurementUnit.scala
@@ -1,0 +1,81 @@
+/* =========================================================================================
+ * Copyright © 2013-2017 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.metric
+
+/**
+  * A MeasurementUnit is a simple representation of the dimension and magnitude of a quantity being measured, such as
+  * "Time in Seconds" or "Data in Kilobytes".
+  */
+case class MeasurementUnit(dimension: MeasurementUnit.Dimension, magnitude: MeasurementUnit.Magnitude)
+
+object MeasurementUnit {
+  val none = MeasurementUnit(Dimension.None, Magnitude("none", 1D))
+
+  val time: TimeUnits = new TimeUnits {
+    val seconds = MeasurementUnit(Dimension.Time, Magnitude("seconds", 1D))
+    val milliseconds = MeasurementUnit(Dimension.Time, Magnitude("milliseconds", 1e-3))
+    val microseconds = MeasurementUnit(Dimension.Time, Magnitude("microseconds", 1e-6))
+    val nanoseconds = MeasurementUnit(Dimension.Time, Magnitude("nanoseconds", 1e-9))
+  }
+
+  val information: DataUnits = new DataUnits {
+    val bytes = MeasurementUnit(Dimension.Information, Magnitude("byte", 1))
+    val kilobytes = MeasurementUnit(Dimension.Information, Magnitude("kilobytes", 1024))
+    val megabytes = MeasurementUnit(Dimension.Information, Magnitude("megabytes", 1024 * 1024))
+    val gigabytes = MeasurementUnit(Dimension.Information, Magnitude("gigabytes", 1024 * 1024 * 1024))
+  }
+
+  /**
+    * Scales the provided value between two MeasurementUnits of the same dimension.
+    *
+    * @param value value to be scaled.
+    * @param from value's [[MeasurementUnit]].
+    * @param to target [[MeasurementUnit]].
+    * @return equivalent of the provided value on the target [[MeasurementUnit]]
+    */
+  def scale(value: Long, from: MeasurementUnit, to: MeasurementUnit): Double = {
+    if (from.dimension != to.dimension)
+      sys.error(
+        s"Can't scale values from the [${from.dimension.name}] dimension into the [${to.dimension.name}] dimension."
+      )
+    else if (from == to)
+      value.toDouble
+    else (from.magnitude.scaleFactor / to.magnitude.scaleFactor) * value.toDouble
+  }
+
+  case class Dimension(name: String)
+  case class Magnitude(name: String, scaleFactor: Double)
+
+  object Dimension {
+    val None = Dimension("none")
+    val Time = Dimension("time")
+    val Information = Dimension("information")
+  }
+
+  trait TimeUnits {
+    def seconds: MeasurementUnit
+    def milliseconds: MeasurementUnit
+    def microseconds: MeasurementUnit
+    def nanoseconds: MeasurementUnit
+  }
+
+  trait DataUnits {
+    def bytes: MeasurementUnit
+    def kilobytes: MeasurementUnit
+    def megabytes: MeasurementUnit
+    def gigabytes: MeasurementUnit
+  }
+}

--- a/src/main/scala/kamon/metric/TickSnapshot.scala
+++ b/src/main/scala/kamon/metric/TickSnapshot.scala
@@ -1,0 +1,75 @@
+/* =========================================================================================
+ * Copyright © 2013-2017 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.metric
+
+/**
+  *
+  * @param interval
+  * @param metrics
+  */
+case class TickSnapshot(interval: Interval, metrics: MetricsSnapshot)
+
+case class Interval(from: Long, to: Long)
+
+case class MetricsSnapshot(
+  histograms: Seq[MetricDistribution],
+  minMaxCounters: Seq[MetricDistribution],
+  gauges: Seq[MetricValue],
+  counters: Seq[MetricValue]
+)
+
+/**
+  * Snapshot for instruments that internally track a single value. Meant to be used for counters and gauges.
+  *
+  */
+case class MetricValue(name: String, tags: Tags, unit: MeasurementUnit, value: Long)
+
+/**
+  * Snapshot for instruments that internally the distribution of values in a defined dynamic range. Meant to be used
+  * with histograms and min max counters.
+  */
+case class MetricDistribution(
+  name: String,
+  tags: Tags,
+  unit: MeasurementUnit,
+  dynamicRange: DynamicRange,
+  distribution: Distribution
+)
+
+trait Distribution {
+  def buckets: Seq[Bucket]
+  def bucketsIterator: Iterator[Bucket]
+
+  def min: Long
+  def max: Long
+  def sum: Long
+  def count: Long
+  def percentile(p: Double): Percentile
+
+  def percentiles: Seq[Percentile]
+  def percentilesIterator: Iterator[Percentile]
+}
+
+trait Bucket {
+  def value: Long
+  def frequency: Long
+}
+
+trait Percentile {
+  def quantile: Double
+  def value: Long
+  def countUnderQuantile: Long
+}

--- a/src/main/scala/kamon/metric/package.scala
+++ b/src/main/scala/kamon/metric/package.scala
@@ -1,0 +1,19 @@
+package kamon
+
+import com.typesafe.config.Config
+
+package object metric {
+
+  type Tags = Map[String, String]
+
+  sealed trait Reporter {
+    def start(): Unit
+    def stop(): Unit
+    def reconfigure(config: Config): Unit
+  }
+
+  trait MetricReporter extends Reporter {
+    def reportTickSnapshot(snapshot: TickSnapshot): Unit
+  }
+
+}

--- a/src/main/scala/kamon/prometheus/PrometheusReporter.scala
+++ b/src/main/scala/kamon/prometheus/PrometheusReporter.scala
@@ -18,7 +18,7 @@ package kamon.prometheus
 import com.typesafe.config.Config
 import fi.iki.elonen.NanoHTTPD
 import fi.iki.elonen.NanoHTTPD.{Response, newFixedLengthResponse}
-import kamon.{Kamon, MetricReporter}
+import kamon.{MetricReporter, Kamon}
 import kamon.metric._
 import org.slf4j.LoggerFactory
 
@@ -36,7 +36,7 @@ class PrometheusReporter extends MetricReporter {
 
 
   override def start(): Unit = {
-    val config = readConfiguration(Kamon.config())
+    val config = readConfiguration(Kamon.config)
 
     if(config.startEmbeddedServer)
       startEmbeddedServer(config)
@@ -59,7 +59,7 @@ class PrometheusReporter extends MetricReporter {
     snapshot.metrics.histograms.foreach(accumulateDistribution(this.histograms, _))
     snapshot.metrics.minMaxCounters.foreach(accumulateDistribution(this.histograms, _))
 
-    val scrapeDataBuilder = new ScrapeDataBuilder(readConfiguration(Kamon.config()))
+    val scrapeDataBuilder = new ScrapeDataBuilder(readConfiguration(Kamon.config))
     scrapeDataBuilder.appendCounters(counters.values.map(_.snapshot()).toSeq)
     scrapeDataBuilder.appendGauges(snapshot.metrics.gauges)
     scrapeDataBuilder.appendHistograms(histograms.values.map(_.snapshot()).toSeq)

--- a/src/main/scala/kamon/prometheus/PrometheusReporterAdapter.scala
+++ b/src/main/scala/kamon/prometheus/PrometheusReporterAdapter.scala
@@ -1,0 +1,44 @@
+package kamon.prometheus
+
+import kamon.Kamon
+import akka.actor.ActorDSL._
+import akka.actor.{ActorRef, PoisonPill, ActorRefFactory}
+import kamon.metric.{SubscriptionFilter, TickSnapshot}
+import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
+
+class PrometheusReporterAdapter(private val subscriptionFilter: SubscriptionFilter, private val converter: TickMetricSnapshot => TickSnapshot)(implicit private val actorRefFactory: ActorRefFactory) extends PrometheusReporter {
+
+  private[prometheus] var subscriber: Option[ActorRef] = None
+
+  override def start(): Unit = {
+    subscriber = Some(actor(new Act {
+      become {
+        case tickSnapshot: TickMetricSnapshot => {
+          reportTickSnapshot(converter(tickSnapshot))
+        }
+      }
+    }))
+
+    Kamon.metrics.subscribe(subscriptionFilter, subscriber.get, permanent = true)
+
+    super.start()
+  }
+
+  override def stop(): Unit = {
+    subscriber.foreach { subscriber =>
+      Kamon.metrics.unsubscribe(subscriber)
+      subscriber ! PoisonPill
+    }
+
+    subscriber = None
+    super.stop()
+  }
+
+}
+
+
+object PrometheusReporterAdapter {
+  def apply(subscriptionFilter: SubscriptionFilter)(implicit actorRefFactory: ActorRefFactory): PrometheusReporterAdapter = {
+    new PrometheusReporterAdapter(subscriptionFilter, TickMetricSnapshotConverter)
+  }
+}

--- a/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
+++ b/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
@@ -12,15 +12,14 @@
  * and limitations under the License.
  * =========================================================================================
  */
- 
+
 package kamon.prometheus
 
 import java.lang.StringBuilder
 import java.text.DecimalFormat
 
-import kamon.metric.{MetricDistribution, MetricValue}
-import kamon.metric.MeasurementUnit
-import kamon.metric.MeasurementUnit.{information, time, none}
+import kamon.metric.{MetricDistribution, MetricValue, MeasurementUnit}
+import kamon.metric.MeasurementUnit.{time, information, none}
 import kamon.metric.MeasurementUnit.Dimension._
 
 class ScrapeDataBuilder(prometheusConfig: PrometheusReporter.Configuration) {

--- a/src/main/scala/kamon/prometheus/TickMetricSnapshotConverter.scala
+++ b/src/main/scala/kamon/prometheus/TickMetricSnapshotConverter.scala
@@ -1,0 +1,191 @@
+package kamon.prometheus
+
+import scala.collection.mutable.ListBuffer
+import scala.collection.concurrent.TrieMap
+import org.HdrHistogram.AtomicHistogram
+import kamon.Kamon
+import kamon.metric.MeasurementUnit.{Dimension, Magnitude}
+import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
+import kamon.metric.instrument._
+import kamon.metric._
+
+object TickMetricSnapshotConverter extends ((TickMetricSnapshot) => TickSnapshot) {
+
+  private def convertUnitOfMeasurement(unitOfMeasurement: UnitOfMeasurement): MeasurementUnit =
+    unitOfMeasurement match {
+      case x: Time =>
+        x.label match {
+          case "n" => MeasurementUnit.time.nanoseconds
+          case "µs" => MeasurementUnit.time.microseconds
+          case "ms" => MeasurementUnit.time.milliseconds
+          case "s" => MeasurementUnit.time.seconds
+        }
+      case x: Memory =>
+        x.label match {
+          case "b" => MeasurementUnit.information.bytes
+          case "Kb" => MeasurementUnit.information.kilobytes
+          case "Mb" => MeasurementUnit.information.megabytes
+          case "Gb" => MeasurementUnit.information.gigabytes
+        }
+      case _ => MeasurementUnit.none
+    }
+
+  private[prometheus] def convertMeasurementUnit(measurementUnit: MeasurementUnit): UnitOfMeasurement =
+    measurementUnit match {
+      case MeasurementUnit(Dimension.Time, Magnitude("seconds", 1D)) => Time.Seconds
+      case MeasurementUnit(Dimension.Time, Magnitude("milliseconds", 1e-3)) => Time.Milliseconds
+      case MeasurementUnit(Dimension.Time, Magnitude("microseconds", 1e-6)) => Time.Microseconds
+      case MeasurementUnit(Dimension.Time, Magnitude("nanoseconds", 1e-9)) => Time.Nanoseconds
+      case MeasurementUnit(Dimension.Information, Magnitude("byte", 1)) => Memory.Bytes
+      case MeasurementUnit(Dimension.Information, Magnitude("kilobytes", 1024)) => Memory.KiloBytes
+      case MeasurementUnit(Dimension.Information, Magnitude("megabytes", 1048576)) => Memory.MegaBytes
+      case MeasurementUnit(Dimension.Information, Magnitude("gigabytes", 1073741824)) => Memory.GigaBytes
+      case MeasurementUnit(Dimension.None, Magnitude("none", 1D)) => UnitOfMeasurement.Unknown
+      case _ => UnitOfMeasurement.Unknown
+    }
+
+  private[prometheus] def toDistribution(snapshot: Histogram.Snapshot): Distribution = new Distribution {
+    override def max: Long = snapshot.max
+
+    override def buckets: Seq[Bucket] = {
+      snapshot.recordsIterator.map { record =>
+        new Bucket {
+          override def frequency: Long = record.count
+          override def value: Long = record.level
+        }
+      }.toSeq
+    }
+
+    override def count: Long = snapshot.numberOfMeasurements
+
+    override def bucketsIterator: Iterator[Bucket] = buckets.toIterator
+
+    override def sum: Long = snapshot.sum
+
+    override def percentilesIterator: Iterator[Percentile] = throw new NotImplementedError()
+    override def percentile(p: Double): Percentile = throw new NotImplementedError()
+    override def percentiles: Seq[Percentile] = throw new NotImplementedError()
+
+    override def min: Long = snapshot.min
+  }
+
+  private val genericEntityRecordInstruments = classOf[GenericEntityRecorder].getDeclaredField("_instruments")
+  genericEntityRecordInstruments.setAccessible(true)
+
+  private val paddedMinMaxCounter = classOf[PaddedMinMaxCounter].getDeclaredField("underlyingHistogram")
+  paddedMinMaxCounter.setAccessible(true)
+
+  private[prometheus] def lookupDynamicRange(entity: Entity, metricKey: MetricKey): Option[DynamicRange] =
+    Kamon.metrics
+      .find(entity)
+      .map {
+        case recorder: HistogramRecorder if recorder.key == metricKey =>
+          recorder.instrument.asInstanceOf[AtomicHistogram]
+        case recorder: MinMaxCounterRecorder =>
+          val minMax = recorder.instrument.asInstanceOf[PaddedMinMaxCounter]
+          paddedMinMaxCounter.get(minMax).asInstanceOf[AtomicHistogram]
+        case recorder: GenericEntityRecorder => {
+          val metricKeyToInstrument =
+            genericEntityRecordInstruments.get(recorder).asInstanceOf[TrieMap[MetricKey, Instrument]]
+
+          metricKeyToInstrument(metricKey) match {
+            case hist: AtomicHistogram => hist
+            case minMax: PaddedMinMaxCounter => paddedMinMaxCounter.get(minMax).asInstanceOf[AtomicHistogram]
+          }
+        }
+      }
+      .map(
+        histogram =>
+          DynamicRange(
+            histogram.getLowestDiscernibleValue,
+            histogram.getHighestTrackableValue,
+            histogram.getNumberOfSignificantValueDigits
+          )
+      )
+
+  private def filterOut(name: String): Option[String] = name match {
+    case "counter" | "histogram" | "min-max-counter" | "gauge" | "trace" | "trace-segment" => None
+    case _ => Some(name)
+  }
+
+  private[prometheus] def toMetricName(entity: Entity, keyName: String): String = {
+    val metricName =
+      filterOut(entity.category).map(category => s"${category}_").getOrElse("") +
+        entity.name +
+        filterOut(keyName).map(keyName => s"_$keyName").getOrElse("")
+
+    metricName
+  }
+
+  private[prometheus] def toMetricDistribution[T <: MetricKey](
+                                                                entity: Entity,
+                                                                metricKey: MetricKey,
+                                                                snapshot: Histogram.Snapshot
+                                                              ): Option[MetricDistribution] = {
+    val dist = toDistribution(snapshot)
+    lookupDynamicRange(entity, metricKey).map { dynamicRange =>
+      MetricDistribution(
+        toMetricName(entity, metricKey.name),
+        entity.tags,
+        convertUnitOfMeasurement(metricKey.unitOfMeasurement),
+        dynamicRange,
+        dist
+      )
+    }
+  }
+
+  private[prometheus] def toMetricValue(entity: Entity, metricKey: MetricKey, snapshot: Counter.Snapshot): MetricValue = MetricValue(
+    toMetricName(entity, metricKey.name),
+    entity.tags,
+    convertUnitOfMeasurement(metricKey.unitOfMeasurement),
+    snapshot.count
+  )
+
+  private[prometheus] def toMetricValue(entity: Entity, metricKey: MetricKey, snapshot: Histogram.Snapshot): MetricValue = {
+    // In Kamon 1.0 gauges are modelled as an AtomicLong in 0.6.7 as a HdrHistogram.
+    //
+    // Hence we map the 0.6.7 histogram snapshot to a single value that represents the "current" value in
+    // the best possible way.
+    val currentValue = snapshot.percentile(1)
+    MetricValue(
+      toMetricName(entity, metricKey.name),
+      entity.tags,
+      convertUnitOfMeasurement(metricKey.unitOfMeasurement),
+      currentValue
+    )
+  }
+
+  def apply(tickMetricSnapshot: TickMetricSnapshot): TickSnapshot = {
+    val counters: ListBuffer[MetricValue] = ListBuffer.empty
+    val gauges: ListBuffer[MetricValue] = ListBuffer.empty
+    val histograms: ListBuffer[MetricDistribution] = ListBuffer.empty
+    val minMaxCounters: ListBuffer[MetricDistribution] = ListBuffer.empty
+
+    for ((entity, entitySnapshot) <- tickMetricSnapshot.metrics) {
+      entitySnapshot.counters.map {
+        case (metricKey, snapshot) => counters += toMetricValue(entity, metricKey, snapshot)
+      }
+      entitySnapshot.gauges.foreach {
+        case (metricKey, snapshot) => gauges += toMetricValue(entity, metricKey, snapshot)
+      }
+      entitySnapshot.histograms.foreach {
+        case (metricKey, snapshot) => toMetricDistribution(entity, metricKey, snapshot).foreach(histograms += _)
+      }
+      entitySnapshot.minMaxCounters.foreach {
+        case (metricKey, snapshot) => toMetricDistribution(entity, metricKey, snapshot).foreach(minMaxCounters += _)
+      }
+    }
+
+    TickSnapshot(
+      Interval(tickMetricSnapshot.from.millis, tickMetricSnapshot.to.millis),
+      MetricsSnapshot(
+        counters = counters,
+        histograms = histograms,
+        minMaxCounters = minMaxCounters,
+        gauges = gauges
+      )
+    )
+  }
+
+
+}

--- a/src/main/scala/org/HdrHistogram/HistogramExtension.scala
+++ b/src/main/scala/org/HdrHistogram/HistogramExtension.scala
@@ -1,0 +1,87 @@
+/* =========================================================================================
+ * Copyright © 2013-2017 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package org.HdrHistogram
+
+import java.nio.ByteBuffer
+import kamon.metric.DynamicRange
+
+trait HdrHistogramOps {
+  def getCountsArraySize(): Int
+  def getFromCountsArray(index: Int): Long
+  def getAndSetFromCountsArray(index: Int, newValue: Long): Long
+  def protectedUnitMagnitude(): Int
+  def protectedSubBucketHalfCount(): Int
+  def protectedSubBucketHalfCountMagnitude(): Int
+}
+
+/**
+  * Exposes package-private members of org.HdrHistogram.AtomicHistogram.
+  */
+abstract class AtomicHistogramExtension(dr: DynamicRange)
+    extends AtomicHistogram(dr.lowestDiscernibleValue, dr.highestTrackableValue, dr.significantValueDigits)
+    with HdrHistogramOps {
+
+  override def incrementTotalCount(): Unit = {}
+  override def addToTotalCount(value: Long): Unit = {}
+
+  override def getCountsArraySize(): Int = counts.length()
+  override def getFromCountsArray(index: Int): Long = counts.get(index)
+  override def getAndSetFromCountsArray(index: Int, newValue: Long): Long = counts.getAndSet(index, newValue)
+
+  override def protectedUnitMagnitude(): Int = unitMagnitude
+  override def protectedSubBucketHalfCount(): Int = subBucketHalfCount
+  override def protectedSubBucketHalfCountMagnitude(): Int = subBucketHalfCountMagnitude
+}
+
+/**
+  * Exposes package-private members of org.HdrHistogram.AtomicHistogram.
+  */
+abstract class SimpleHistogramExtension(dr: DynamicRange)
+    extends Histogram(dr.lowestDiscernibleValue, dr.highestTrackableValue, dr.significantValueDigits)
+    with HdrHistogramOps {
+
+  override def incrementTotalCount(): Unit = {}
+  override def addToTotalCount(value: Long): Unit = {}
+
+  override def getCountsArraySize(): Int = counts.length
+  override def getFromCountsArray(index: Int): Long = getCountAtIndex(index)
+  override def getAndSetFromCountsArray(index: Int, newValue: Long): Long = {
+    val v = getCountAtIndex(index)
+    setCountAtIndex(index, newValue)
+    v
+  }
+
+  override def protectedUnitMagnitude(): Int = unitMagnitude
+  override def protectedSubBucketHalfCount(): Int = subBucketHalfCount
+  override def protectedSubBucketHalfCountMagnitude(): Int = subBucketHalfCountMagnitude
+}
+
+/**
+  * Exposes the package-private members of org.HdrHistogram.ZigZagEncoding.
+  */
+object ZigZag {
+  def putLong(buffer: ByteBuffer, value: Long): Unit =
+    ZigZagEncoding.putLong(buffer, value)
+
+  def getLong(buffer: ByteBuffer): Long =
+    ZigZagEncoding.getLong(buffer)
+
+  def putInt(buffer: ByteBuffer, value: Int): Unit =
+    ZigZagEncoding.putInt(buffer, value)
+
+  def getInt(buffer: ByteBuffer): Int =
+    ZigZagEncoding.getInt(buffer)
+}

--- a/src/test/scala/kamon/prometheus/PrometheusReporterAdapterSpec.scala
+++ b/src/test/scala/kamon/prometheus/PrometheusReporterAdapterSpec.scala
@@ -1,0 +1,66 @@
+package kamon.prometheus
+
+import akka.actor.{Terminated, ActorSystem}
+import akka.testkit.{TestProbe, TestKit, ImplicitSender}
+import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
+import kamon.metric.SubscriptionFilter
+import kamon.util.MilliTimestamp
+import org.scalatest.concurrent.Eventually
+import org.scalatest.{BeforeAndAfterAll, WordSpecLike, Matchers}
+
+class PrometheusReporterAdapterSpec extends TestKit(ActorSystem("PrometheusReporterAdapterSpec")) with ImplicitSender
+  with WordSpecLike with Matchers with BeforeAndAfterAll with Eventually {
+
+  "the prometheus reporter adapter" should {
+
+    def createReporter(): PrometheusReporterAdapter = {
+      new PrometheusReporterAdapter(SubscriptionFilter("", ""), TickMetricSnapshotConverter)(system)
+    }
+
+    "register a subscriber after starting and deregister it when stopping" in {
+      val reporter = createReporter()
+
+      reporter.subscriber.isEmpty shouldBe true
+      reporter.start()
+      reporter.subscriber.isEmpty shouldBe false
+
+      val probe = TestProbe()
+      probe.watch(reporter.subscriber.get)
+
+      reporter.stop()
+      probe.expectMsgClass(classOf[Terminated])
+      reporter.subscriber.isEmpty shouldBe true
+    }
+
+    "allow stopping before starting" in {
+      val reporter = createReporter()
+      reporter.stop()
+      reporter.subscriber.isEmpty shouldBe true
+    }
+
+    "map the old to the new tick snapshot format" in {
+      val reporter = createReporter()
+
+      val initialScrapeData = reporter.scrapeData()
+
+      reporter.start()
+
+      reporter.subscriber.foreach(_ ! TickMetricSnapshot(
+        from = MilliTimestamp(1L),
+        to = MilliTimestamp(2L),
+        metrics = Map.empty
+      ))
+
+      try {
+        eventually {
+          reporter.scrapeData() shouldNot be(initialScrapeData)
+        }
+      } finally {
+        reporter.stop()
+      }
+
+    }
+
+  }
+
+}

--- a/src/test/scala/kamon/prometheus/TickMetricSnapshotConverterSpec.scala
+++ b/src/test/scala/kamon/prometheus/TickMetricSnapshotConverterSpec.scala
@@ -1,0 +1,142 @@
+package kamon.prometheus
+
+import kamon.Kamon
+import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
+import kamon.metric.instrument.{Histogram, Time, UnitOfMeasurement, CounterSnapshot}
+import kamon.metric._
+import kamon.util.MilliTimestamp
+import org.scalatest.{Matchers, WordSpec}
+
+class TickMetricSnapshotConverterSpec extends WordSpec with Matchers {
+
+  "the tick metric snapshot converter" should {
+
+    val EmptyTickMetricSnapshot = TickMetricSnapshot(
+      from = MilliTimestamp(1L),
+      to = MilliTimestamp(2L),
+      metrics = Map.empty
+    )
+
+    val EmptyTickSnapshot= TickSnapshot(interval = Interval(from = 1L, to = 2L), MetricsSnapshot(
+      histograms = Seq.empty,
+      minMaxCounters = Seq.empty,
+      gauges = Seq.empty,
+      counters = Seq.empty
+    ))
+
+    "leave an empty tick snapshot empty upon conversion" in {
+      TickMetricSnapshotConverter(EmptyTickMetricSnapshot) shouldBe EmptyTickSnapshot
+    }
+
+    "convert counters" in {
+      val oldSnapshot = {
+        val metrics = {
+          val entity = Entity("http_request", "counter", Map("status" -> "500"))
+          val snapshot = new DefaultEntitySnapshot(Map(
+            CounterKey(name = "counter", unitOfMeasurement = UnitOfMeasurement.Unknown) -> CounterSnapshot(count = 1L)
+          ))
+          Map(entity -> snapshot)
+        }
+
+        EmptyTickMetricSnapshot.copy(metrics = metrics)
+      }
+
+      val newSnapshot = EmptyTickSnapshot.copy(
+        metrics = EmptyTickSnapshot.metrics.copy(
+          counters = Seq(MetricValue(
+            name = "http_request",
+            tags = Map("status" -> "500"),
+            unit = MeasurementUnit.none,
+            value = 1L
+          ))
+      ))
+
+      TickMetricSnapshotConverter(oldSnapshot) shouldBe newSnapshot
+    }
+
+    "convert gauges" in {
+      val oldSnapshot = {
+        val metrics = {
+          val entity = Entity("build_info", "gauge", Map("version" -> "v1.0"))
+          val snapshot = new DefaultEntitySnapshot(Map(
+            GaugeKey(name = "gauge", unitOfMeasurement = UnitOfMeasurement.Unknown) -> Histogram.Snapshot.empty
+          ))
+          Map(entity -> snapshot)
+        }
+
+        EmptyTickMetricSnapshot.copy(metrics = metrics)
+      }
+
+      val newSnapshot = EmptyTickSnapshot.copy(
+        metrics = EmptyTickSnapshot.metrics.copy(
+          gauges = Seq(MetricValue(
+            name = "build_info",
+            tags = Map("version" -> "v1.0"),
+            unit = MeasurementUnit.none,
+            value = 0L
+          ))
+        ))
+
+      TickMetricSnapshotConverter(oldSnapshot) shouldBe newSnapshot
+    }
+
+    "convert histograms" in {
+      val oldSnapshot = {
+        Kamon.metrics.histogram("http_request_duration", Map("status" -> "500"), Time.Milliseconds)
+
+        val metrics = {
+          val entity = Entity("http_request_duration", "histogram", Map("status" -> "500"))
+          val snapshot = new DefaultEntitySnapshot(Map(
+            HistogramKey(name = "histogram", unitOfMeasurement = Time.Milliseconds) -> Histogram.Snapshot.empty
+          ))
+          Map(entity -> snapshot)
+        }
+
+        EmptyTickMetricSnapshot.copy(metrics = metrics)
+      }
+
+      val actual = TickMetricSnapshotConverter(oldSnapshot)
+      actual.metrics.histograms.size shouldBe 1
+
+      val metricDistribution = actual.metrics.histograms.head
+      metricDistribution.name shouldBe "http_request_duration"
+      metricDistribution.tags shouldBe Map("status" -> "500")
+      metricDistribution.unit shouldBe MeasurementUnit.time.milliseconds
+      metricDistribution.dynamicRange shouldBe DynamicRange(1L,3600000000000L,2)
+      metricDistribution.distribution.count shouldBe 0L
+      metricDistribution.distribution.min shouldBe 0L
+      metricDistribution.distribution.max shouldBe 0L
+    }
+
+
+    "convert min-max-counters" in {
+      val oldSnapshot = {
+        Kamon.metrics.minMaxCounter("http_queue_length", Map("status" -> "500"), Time.Milliseconds)
+
+        val metrics = {
+          val entity = Entity("http_queue_length", "min-max-counter", Map("status" -> "500"))
+          val snapshot = new DefaultEntitySnapshot(Map(
+            MinMaxCounterKey(name = "min-max-counter", unitOfMeasurement = Time.Milliseconds) -> Histogram.Snapshot.empty
+          ))
+          Map(entity -> snapshot)
+        }
+
+        EmptyTickMetricSnapshot.copy(metrics = metrics)
+      }
+
+      val actual = TickMetricSnapshotConverter(oldSnapshot)
+      actual.metrics.minMaxCounters.size shouldBe 1
+
+      val metricDistribution = actual.metrics.minMaxCounters.head
+      metricDistribution.name shouldBe "http_queue_length"
+      metricDistribution.tags shouldBe Map("status" -> "500")
+      metricDistribution.unit shouldBe MeasurementUnit.time.milliseconds
+      metricDistribution.dynamicRange shouldBe DynamicRange(1L,999999999L,2)
+      metricDistribution.distribution.count shouldBe 0L
+      metricDistribution.distribution.min shouldBe 0L
+      metricDistribution.distribution.max shouldBe 0L
+    }
+
+  }
+
+}


### PR DESCRIPTION
A backport to Kamon 0.6.7 . 

It contains:
- a dissection of the Kamon 1RC and HdrHistogram code under `kamon/metric` and `org/HdrHistogram` necessary for compilation
- an adapter `PrometheusReporterAdapter` that converts the 0.6.7 tick snapshot model to the Kamon 1 RC model

Warning: do not merge, this MR probably shouldn't endup in master, but in a branch instead.