### PR TITLE
Update reference.conf

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -52,7 +52,7 @@ kamon.prometheus {
 
   embedded-server {
     # Hostname and port used by the embedded web server to publish the scraping enpoint.
-    hostname = localhost
+    hostname = 0.0.0.0
     port = 9095
   }
 }


### PR DESCRIPTION
I believe hostname should be `0.0.0.0` instead of `localhost`, because it is not possible to access the the endpoint from outside