### PR TITLE
Use Locale.ROOT for formatting the numbers

### DIFF
--- a/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
+++ b/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
@@ -16,7 +16,8 @@
 package kamon.prometheus
 
 import java.lang.StringBuilder
-import java.text.DecimalFormat
+import java.text.{DecimalFormat, DecimalFormatSymbols}
+import java.util.Locale
 
 import kamon.metric.{MetricDistribution, MetricValue}
 import kamon.metric.MeasurementUnit
@@ -25,7 +26,8 @@ import kamon.metric.MeasurementUnit.Dimension._
 
 class ScrapeDataBuilder(prometheusConfig: PrometheusReporter.Configuration) {
   private val builder = new StringBuilder()
-  private val numberFormat = new DecimalFormat("#0.0########")
+  private val decimalFormatSymbols = DecimalFormatSymbols.getInstance(Locale.ROOT)
+  private val numberFormat = new DecimalFormat("#0.0########", decimalFormatSymbols)
 
   import builder.append
 


### PR DESCRIPTION
Under Finnish locale, for example, numbers are formatted as `12,34` without this fix.

Didn't add any additional tests since the existing tests already assume `.` as the decimal separator and as such already failed for me by default :)