### PR TITLE
Include tags from Kamon.environment.tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,25 @@ scrape_configs:
 
 [1]: https://github.com/kamon-io/kamon-prometheus/blob/master/src/main/resources/reference.conf
 [2]: http://prometheus.io/docs/operating/configuration/#scrape-configurations-scrape_config
+
+#### Custom environment tags
+Kamon allows you to provide custom environment tags to all your metrics by configuring `kamon.environment.tags` in your `application.conf`, e.g.
+```
+kamon.environment.tags {
+  custom.id = "test1"
+  env = staging
+}
+```
+In order to include these tags in your Prometheus metrics as well, you need to activate this feature for the `PrometheusReporter` by setting
+```
+kamon.prometheus.include-environment-tags = yes
+```
+in your `application.conf` as well, yielding, for example
+```
+# TYPE some_metric_seconds_total counter
+some_metric_seconds_total{custom_id="test1",env="staging"} 10.0
+# TYPE some_metric_seconds gauge
+some_metric_seconds{custom_id="test1",env="staging"} 10.0
+```
+
+Note that environment tags always have precedence over any other custom tag that may have been set by the application at runtime.

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@
  */
 
 resolvers += Resolver.bintrayRepo("kamon-io", "snapshots")
-val kamonCore = "io.kamon" %% "kamon-core" % "1.0.0"
+val kamonCore = "io.kamon" %% "kamon-core" % "1.1.0"
 val nanohttpd = "org.nanohttpd" % "nanohttpd" % "2.3.1"
 
 lazy val root = (project in file("."))

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -7,6 +7,9 @@ kamon.prometheus {
   # Enable or disable publishing the Prometheus scraping enpoint using a embedded server.
   start-embedded-http-server = yes
 
+  # Enable of disable including tags from kamon.prometheus.environment as labels
+  include-environment-tags = no
+
   buckets {
     default-buckets = [
       10,

--- a/src/main/scala/kamon/prometheus/PrometheusReporter.scala
+++ b/src/main/scala/kamon/prometheus/PrometheusReporter.scala
@@ -57,7 +57,7 @@ class PrometheusReporter extends MetricReporter {
   override def reportPeriodSnapshot(snapshot: PeriodSnapshot): Unit = {
     snapshotAccumulator.add(snapshot)
     val currentData = snapshotAccumulator.peek()
-    val scrapeDataBuilder = new ScrapeDataBuilder(readConfiguration(Kamon.config()))
+    val scrapeDataBuilder = new ScrapeDataBuilder(readConfiguration(Kamon.config()), Kamon.environment.tags)
 
     scrapeDataBuilder.appendCounters(currentData.metrics.counters)
     scrapeDataBuilder.appendGauges(currentData.metrics.gauges)

--- a/src/main/scala/kamon/prometheus/PrometheusReporter.scala
+++ b/src/main/scala/kamon/prometheus/PrometheusReporter.scala
@@ -57,7 +57,8 @@ class PrometheusReporter extends MetricReporter {
   override def reportPeriodSnapshot(snapshot: PeriodSnapshot): Unit = {
     snapshotAccumulator.add(snapshot)
     val currentData = snapshotAccumulator.peek()
-    val scrapeDataBuilder = new ScrapeDataBuilder(readConfiguration(Kamon.config()), Kamon.environment.tags)
+    val reporterConfiguration = readConfiguration(Kamon.config())
+    val scrapeDataBuilder = new ScrapeDataBuilder(reporterConfiguration, environmentTags(reporterConfiguration))
 
     scrapeDataBuilder.appendCounters(currentData.metrics.counters)
     scrapeDataBuilder.appendGauges(currentData.metrics.gauges)
@@ -97,12 +98,17 @@ class PrometheusReporter extends MetricReporter {
       embeddedServerPort = prometheusConfig.getInt("embedded-server.port"),
       defaultBuckets = prometheusConfig.getDoubleList("buckets.default-buckets").asScala,
       timeBuckets = prometheusConfig.getDoubleList("buckets.time-buckets").asScala,
-      informationBuckets = prometheusConfig.getDoubleList("buckets.information-buckets").asScala
+      informationBuckets = prometheusConfig.getDoubleList("buckets.information-buckets").asScala,
+      includeEnvironmentTags = prometheusConfig.getBoolean("include-environment-tags")
     )
   }
+
+  private def environmentTags(reporterConfiguration: PrometheusReporter.Configuration) =
+    if (reporterConfiguration.includeEnvironmentTags) Kamon.environment.tags else Map.empty[String, String]
 }
 
 object PrometheusReporter {
   case class Configuration(startEmbeddedServer: Boolean, embeddedServerHostname: String, embeddedServerPort: Int,
-    defaultBuckets: Seq[java.lang.Double], timeBuckets: Seq[java.lang.Double], informationBuckets: Seq[java.lang.Double])
+    defaultBuckets: Seq[java.lang.Double], timeBuckets: Seq[java.lang.Double], informationBuckets: Seq[java.lang.Double],
+    includeEnvironmentTags: Boolean)
 }

--- a/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
+++ b/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
@@ -141,7 +141,7 @@ class ScrapeDataBuilder(prometheusConfig: PrometheusReporter.Configuration, envi
 
 
   private def appendTags(tags: Map[String, String]): Unit = {
-    val allTags = environmentTags ++ tags
+    val allTags = tags ++ environmentTags
     if(allTags.nonEmpty) append("{")
 
     val tagIterator = allTags.iterator

--- a/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
+++ b/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
@@ -19,12 +19,13 @@ import java.lang.StringBuilder
 import java.text.{DecimalFormat, DecimalFormatSymbols}
 import java.util.Locale
 
+import kamon.Environment
 import kamon.metric.{MetricDistribution, MetricValue}
 import kamon.metric.MeasurementUnit
 import kamon.metric.MeasurementUnit.{information, time, none}
 import kamon.metric.MeasurementUnit.Dimension._
 
-class ScrapeDataBuilder(prometheusConfig: PrometheusReporter.Configuration) {
+class ScrapeDataBuilder(prometheusConfig: PrometheusReporter.Configuration, environmentTags: Map[String, String] = Map.empty) {
   private val builder = new StringBuilder()
   private val decimalFormatSymbols = DecimalFormatSymbols.getInstance(Locale.ROOT)
   private val numberFormat = new DecimalFormat("#0.0########", decimalFormatSymbols)
@@ -140,9 +141,10 @@ class ScrapeDataBuilder(prometheusConfig: PrometheusReporter.Configuration) {
 
 
   private def appendTags(tags: Map[String, String]): Unit = {
-    if(tags.nonEmpty) append("{")
+    val allTags = environmentTags ++ tags
+    if(allTags.nonEmpty) append("{")
 
-    val tagIterator = tags.iterator
+    val tagIterator = allTags.iterator
     var tagCount = 0
 
     while(tagIterator.hasNext) {
@@ -152,7 +154,7 @@ class ScrapeDataBuilder(prometheusConfig: PrometheusReporter.Configuration) {
       tagCount += 1
     }
 
-    if(tags.nonEmpty) append("}")
+    if(allTags.nonEmpty) append("}")
   }
 
   private def normalizeMetricName(metricName: String, unit: MeasurementUnit): String = {

--- a/src/test/scala/kamon/prometheus/ScrapeDataBuilderSpec.scala
+++ b/src/test/scala/kamon/prometheus/ScrapeDataBuilderSpec.scala
@@ -194,9 +194,25 @@ class ScrapeDataBuilderSpec extends WordSpec with Matchers {
       .build() should include {
         """
           |# TYPE counter_one_seconds_total counter
-          |counter_one_seconds_total{env_key="env_value",tag_with_dots="value"} 10.0
+          |counter_one_seconds_total{tag_with_dots="value",env_key="env_value"} 10.0
           |# TYPE gauge_one_seconds gauge
           |gauge_one_seconds{env_key="env_value"} 20.0
+        """.stripMargin.trim()
+      }
+    }
+
+    "let environment tags have precedence over custom tags" in {
+      val metric = MetricValue("some-metric", Map("custom.tag" -> "custom-value"), time.seconds, 10)
+
+      builder(environmentTags = Map("custom.tag" -> "environment-value"))
+        .appendCounters(Seq(metric))
+        .appendGauges(Seq(metric))
+        .build() should include {
+        """
+          |# TYPE some_metric_seconds_total counter
+          |some_metric_seconds_total{custom_tag="environment-value"} 10.0
+          |# TYPE some_metric_seconds gauge
+          |some_metric_seconds{custom_tag="environment-value"} 10.0
         """.stripMargin.trim()
       }
     }

--- a/src/test/scala/kamon/prometheus/ScrapeDataBuilderSpec.scala
+++ b/src/test/scala/kamon/prometheus/ScrapeDataBuilderSpec.scala
@@ -203,7 +203,7 @@ class ScrapeDataBuilderSpec extends WordSpec with Matchers {
   }
 
   private def builder(buckets: Seq[java.lang.Double] = Seq(5D, 7D, 8D, 9D, 10D, 11D, 12D), environmentTags: Map[String, String] = Map.empty) = new ScrapeDataBuilder(
-    PrometheusReporter.Configuration(false, "localhost", 1, buckets, buckets, buckets), environmentTags
+    PrometheusReporter.Configuration(false, "localhost", 1, buckets, buckets, buckets, false), environmentTags
   )
 
   private def constantDistribution(name: String, tags: Map[String, String], unit: MeasurementUnit, lower: Int, upper: Int): MetricDistribution = {

--- a/src/test/scala/kamon/prometheus/ScrapeDataBuilderSpec.scala
+++ b/src/test/scala/kamon/prometheus/ScrapeDataBuilderSpec.scala
@@ -183,10 +183,27 @@ class ScrapeDataBuilderSpec extends WordSpec with Matchers {
         """.stripMargin.trim()
       }
     }
+
+    "include global custom tags from the Kamon.environment.tags" in {
+      val counterOne = MetricValue("counter-one", Map("tag.with.dots" -> "value"), time.seconds, 10)
+      val gaugeOne = MetricValue("gauge-one", Map.empty, time.seconds, 20)
+
+      builder(environmentTags = Map("env_key" -> "env_value"))
+      .appendCounters(Seq(counterOne))
+      .appendGauges(Seq(gaugeOne))
+      .build() should include {
+        """
+          |# TYPE counter_one_seconds_total counter
+          |counter_one_seconds_total{env_key="env_value",tag_with_dots="value"} 10.0
+          |# TYPE gauge_one_seconds gauge
+          |gauge_one_seconds{env_key="env_value"} 20.0
+        """.stripMargin.trim()
+      }
+    }
   }
 
-  private def builder(buckets: Seq[java.lang.Double] = Seq(5D, 7D, 8D, 9D, 10D, 11D, 12D)) = new ScrapeDataBuilder(
-    PrometheusReporter.Configuration(false, "localhost", 1, buckets, buckets, buckets)
+  private def builder(buckets: Seq[java.lang.Double] = Seq(5D, 7D, 8D, 9D, 10D, 11D, 12D), environmentTags: Map[String, String] = Map.empty) = new ScrapeDataBuilder(
+    PrometheusReporter.Configuration(false, "localhost", 1, buckets, buckets, buckets), environmentTags
   )
 
   private def constantDistribution(name: String, tags: Map[String, String], unit: MeasurementUnit, lower: Int, upper: Int): MetricDistribution = {


### PR DESCRIPTION
Since https://github.com/kamon-io/Kamon/pull/515 it is now possible to provide custom tags in the `application.conf`:
```
kamon.environment.tags {
  custom1 = "test1"
  env = staging
}
```

With this PR, this reporter includes these tags as well.