### PR TITLE
Allow to override buckets for particular metrics

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -47,6 +47,12 @@ kamon.prometheus {
       524288,
       1048576
     ]
+
+    # Per metric overrides are possible by specifying the prometheus metric name and the histogram buckets here
+    custom {
+      // example:
+      // "akka_actor_processing_time_seconds" = [0.1, 1.0, 10.0]
+    }
   }
 
 

--- a/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
+++ b/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
@@ -96,11 +96,14 @@ class ScrapeDataBuilder(prometheusConfig: PrometheusReporter.Configuration) {
   }
 
   private def appendHistogramBuckets(name: String, tags: Map[String, String], metric: MetricDistribution): Unit = {
-    val configuredBuckets = (metric.unit.dimension match {
-      case Time         => prometheusConfig.timeBuckets
-      case Information  => prometheusConfig.informationBuckets
-      case _            => prometheusConfig.defaultBuckets
-    }).iterator
+    val configuredBuckets = prometheusConfig.customBuckets.getOrElse(
+      name,
+      metric.unit.dimension match {
+        case Time => prometheusConfig.timeBuckets
+        case Information => prometheusConfig.informationBuckets
+        case _ => prometheusConfig.defaultBuckets
+      }
+    ).iterator
 
     val distributionBuckets = metric.distribution.bucketsIterator
     var currentDistributionBucket = distributionBuckets.next()


### PR DESCRIPTION
By specifying custom buckets for a single metric, the default (unit-based)
buckets can be overriden:

    kamon.prometheus.buckets.custom.metric_name = [1, 2, 3]

Example:

    kamon.prometheus.buckets.custom {
      akka_actor_processing_time_seconds = [0.1, 0.2, 1]
    }

Open issues:

- how to test that the config is correctly read?