### PR TITLE
Feedback on #12

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -51,15 +51,16 @@ kamon.prometheus {
       1048576
     ]
 
-    # Per metric overrides are possible by specifying the prometheus metric name and the histogram buckets here
+    # Per metric overrides are possible by specifying the metric name and the histogram buckets here
     custom {
       // example:
-      // "akka_actor_processing_time_seconds" = [0.1, 1.0, 10.0]
+      // "akka.actor.processing-time" = [0.1, 1.0, 10.0]
     }
   }
 
 
   embedded-server {
+
     # Hostname and port used by the embedded web server to publish the scraping enpoint.
     hostname = 0.0.0.0
     port = 9095

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -50,6 +50,12 @@ kamon.prometheus {
       524288,
       1048576
     ]
+
+    # Per metric overrides are possible by specifying the prometheus metric name and the histogram buckets here
+    custom {
+      // example:
+      // "akka_actor_processing_time_seconds" = [0.1, 1.0, 10.0]
+    }
   }
 
 

--- a/src/main/scala/kamon/prometheus/PrometheusReporter.scala
+++ b/src/main/scala/kamon/prometheus/PrometheusReporter.scala
@@ -13,7 +13,8 @@
  * =========================================================================================
  */
 
-package kamon.prometheus
+package kamon
+package prometheus
 
 import java.time.Duration
 
@@ -99,7 +100,7 @@ class PrometheusReporter extends MetricReporter {
       defaultBuckets = prometheusConfig.getDoubleList("buckets.default-buckets").asScala,
       timeBuckets = prometheusConfig.getDoubleList("buckets.time-buckets").asScala,
       informationBuckets = prometheusConfig.getDoubleList("buckets.information-buckets").asScala,
-      customBuckets = getMappedDoubleList("buckets.custom", prometheusConfig),
+      customBuckets = readCustomBuckets(prometheusConfig.getConfig("buckets.custom")),
       includeEnvironmentTags = prometheusConfig.getBoolean("include-environment-tags")
     )
   }
@@ -107,12 +108,11 @@ class PrometheusReporter extends MetricReporter {
   private def environmentTags(reporterConfiguration: PrometheusReporter.Configuration) =
     if (reporterConfiguration.includeEnvironmentTags) Kamon.environment.tags else Map.empty[String, String]
 
-  private def getMappedDoubleList(key: String, conf: Config) = {
-    val cnf = conf.getConfig(key)
-    val keyMap = conf.getObject(key).asScala
-    (for ((k, v) <- keyMap if v.valueType() == ConfigValueType.LIST) yield
-      k -> cnf.getDoubleList(k).asScala.toList).toMap
-  }
+  private def readCustomBuckets(customBuckets: Config): Map[String, Seq[java.lang.Double]] =
+    customBuckets
+      .topLevelKeys
+      .map(k => (k, customBuckets.getDoubleList(k).asScala))
+      .toMap
 
 }
 

--- a/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
+++ b/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
@@ -97,11 +97,14 @@ class ScrapeDataBuilder(prometheusConfig: PrometheusReporter.Configuration, envi
   }
 
   private def appendHistogramBuckets(name: String, tags: Map[String, String], metric: MetricDistribution): Unit = {
-    val configuredBuckets = (metric.unit.dimension match {
-      case Time         => prometheusConfig.timeBuckets
-      case Information  => prometheusConfig.informationBuckets
-      case _            => prometheusConfig.defaultBuckets
-    }).iterator
+    val configuredBuckets = prometheusConfig.customBuckets.getOrElse(
+      name,
+      metric.unit.dimension match {
+        case Time => prometheusConfig.timeBuckets
+        case Information => prometheusConfig.informationBuckets
+        case _ => prometheusConfig.defaultBuckets
+      }
+    ).iterator
 
     val distributionBuckets = metric.distribution.bucketsIterator
     var currentDistributionBucket = distributionBuckets.next()

--- a/src/test/scala/kamon/prometheus/ScrapeDataBuilderSpec.scala
+++ b/src/test/scala/kamon/prometheus/ScrapeDataBuilderSpec.scala
@@ -92,10 +92,10 @@ class ScrapeDataBuilderSpec extends WordSpec with Matchers {
       }
     }
 
-    "custom histogram buckets override defaults" in {
+    "override histogram buckets with custom configuration" in {
       val customBucketsHistogram = constantDistribution("histogram.custom-buckets", Map.empty, none, 1, 10)
 
-      builder(customBuckets = Map("histogram_custom_buckets" -> Seq(1D, 2D, 4D))).appendHistograms(Seq(customBucketsHistogram)).build() should include {
+      builder(customBuckets = Map("histogram.custom-buckets" -> Seq(1D, 2D, 4D))).appendHistograms(Seq(customBucketsHistogram)).build() should include {
         """
           |# TYPE histogram_custom_buckets histogram
           |histogram_custom_buckets_bucket{le="1.0"} 1.0


### PR DESCRIPTION
Hey @StephenKing, I rebased #12 on top of master and applied one extra change: use the Kamon metric names for matching custom buckets instead of Prometheus'. The reasoning behind it is that it seems more natural to match against the metric name that users will see in the code where they define it or in the documentation rather than in the external format, given the fact that its a Kamon-specific configuration.

Your PR is a good addition, hope this helps move it forward and get this feature in!
