### PR TITLE
Always stop embedded server during reconfigure

### DIFF
--- a/src/main/scala/kamon/prometheus/PrometheusReporter.scala
+++ b/src/main/scala/kamon/prometheus/PrometheusReporter.scala
@@ -50,8 +50,9 @@ class PrometheusReporter extends MetricReporter {
 
   override def reconfigure(newConfig: Config): Unit = {
     val config = readConfiguration(newConfig)
+
+    stopEmbeddedServer()
     if(config.startEmbeddedServer) {
-      stopEmbeddedServer()
       startEmbeddedServer(config)
     }
   }


### PR DESCRIPTION
Currently, if the embedded server was started before reconfigure, and then Kamon is reconfigured with `start-embedded-http-server = no`, the embedded server would not be stopped.
With this little change, the embedded server would be stopped in any case.