### PR TITLE
set `stalePeriod` to avoid clean metrics in `PeriodSnapshot.Accumulator`

### DIFF
--- a/src/main/scala/kamon/prometheus/PrometheusReporter.scala
+++ b/src/main/scala/kamon/prometheus/PrometheusReporter.scala
@@ -33,7 +33,7 @@ class PrometheusReporter(configPath: String) extends MetricReporter {
 
   private val _logger = LoggerFactory.getLogger(classOf[PrometheusReporter])
   private var _embeddedHttpServer: Option[EmbeddedHttpServer] = None
-  private val _snapshotAccumulator = PeriodSnapshot.accumulator(Duration.ofDays(365 * 5), Duration.ZERO)
+  private val _snapshotAccumulator = PeriodSnapshot.accumulator(Duration.ofDays(365 * 5), Duration.ZERO, Duration.ofDays(365 * 5))
 
   @volatile private var _preparedScrapeData: String =
     "# The kamon-prometheus module didn't receive any data just yet.\n"


### PR DESCRIPTION
https://github.com/kamon-io/Kamon/issues/566#issuecomment-567835368

Today our server does **not** expose any metrics. So I fix it.